### PR TITLE
Move the unit tests to using karma, phantomjs, mocha, chai and sinon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ uideps:
 uilint:
 	cd cmd/tchaik/ui; gulp lint
 uitest:
-	cd cmd/tchaik/ui; npm run test
+	cd cmd/tchaik/ui; gulp test

--- a/cmd/tchaik/ui/gulpfile.js
+++ b/cmd/tchaik/ui/gulpfile.js
@@ -3,6 +3,7 @@ var gulp = require('gulp');
 var _ = require('lodash');
 var gutil = require('gulp-util');
 var jshint = require('gulp-jshint');
+var karma = require('gulp-karma');
 var webpack = require('webpack');
 var webpackDevServer = require('webpack-dev-server');
 
@@ -106,5 +107,32 @@ gulp.task('serve', function() {
   server.listen(3000);
 });
 
+
+function setupKarma(options) {
+  return gulp.src([
+    // Polyfill so we can use react in phantomjs
+    './node_modules/phantomjs-polyfill/bind-polyfill.js',
+    // Test files
+    'static/js/src/**/*-test.js'
+  ])
+  .pipe(karma(_.assign({
+    configFile: 'karma.conf.js',
+    browsers: ['PhantomJS'],
+  }, options)));
+}
+
+gulp.task('karma:ci', function() {
+  return setupKarma({
+    action: 'run',
+  });
+});
+
+gulp.task('karma:dev', function() {
+  return setupKarma({
+    action: 'watch',
+  });
+});
+
 gulp.task('default', ['webpack', 'jshint:jsx']);
 gulp.task('lint', ['jshint', 'jshint:jsx']);
+gulp.task('test', ['karma:ci']);

--- a/cmd/tchaik/ui/gulpfile.js
+++ b/cmd/tchaik/ui/gulpfile.js
@@ -13,6 +13,7 @@ var paths = {
     dest: 'static/css'
   },
   js: {
+    tests: 'static/js/src/**/*-test.js',
     entry: './static/js/src/app.js',
     bundleName: 'tchaik.js',
     dest: 'static/js/build'
@@ -113,7 +114,7 @@ function setupKarma(options) {
     // Polyfill so we can use react in phantomjs
     './node_modules/phantomjs-polyfill/bind-polyfill.js',
     // Test files
-    'static/js/src/**/*-test.js'
+    paths.js.tests,
   ])
   .pipe(karma(_.assign({
     configFile: 'karma.conf.js',

--- a/cmd/tchaik/ui/gulpfile.js
+++ b/cmd/tchaik/ui/gulpfile.js
@@ -55,6 +55,12 @@ var jshintConfig = {
   unused: true,
   node: true,
   newcap: false,
+  globals: {
+    'beforeEach': false,
+    'describe': false,
+    'expect': false,
+    'it': false,
+  }
 };
 
 gulp.task('jshint', function() {
@@ -65,19 +71,12 @@ gulp.task('jshint', function() {
 });
 
 gulp.task('jshint:jsx', function() {
+  var config = _.assign({}, jshintConfig, {
+    linter: require('jshint-jsx').JSXHINT,
+  });
+
   return gulp.src(['static/js/src/components/*.js'])
-    .pipe(jshint({
-      linter: require('jshint-jsx').JSXHINT,
-      esnext: true,
-      browser: true,
-      devel: true,
-      jquery: true,
-      curly: true,
-      undef: true,
-      unused: true,
-      node: true,
-      newcap: false
-    }))
+    .pipe(jshint(config))
     .pipe(jshint.reporter('jshint-stylish'))
     .pipe(jshint.reporter('fail'));
 });

--- a/cmd/tchaik/ui/karma.conf.js
+++ b/cmd/tchaik/ui/karma.conf.js
@@ -1,0 +1,9 @@
+module.exports = function(config) {
+  config.set({
+    frameworks: ['mocha', 'sinon-chai'],
+    preprocessors: {
+      'static/**/*.js': ['webpack']
+    },
+    webpack: require('./webpack.tests.config.js'),
+  });
+};

--- a/cmd/tchaik/ui/karma.conf.js
+++ b/cmd/tchaik/ui/karma.conf.js
@@ -5,5 +5,9 @@ module.exports = function(config) {
       'static/**/*.js': ['webpack']
     },
     webpack: require('./webpack.tests.config.js'),
+    reporters: ['mocha'],
+    mochaReporter: {
+      output: 'autowatch',
+    }
   });
 };

--- a/cmd/tchaik/ui/package.json
+++ b/cmd/tchaik/ui/package.json
@@ -10,11 +10,17 @@
     "flux": "^2.0.1",
     "gulp": "^3.8.11",
     "gulp-jshint": "^1.10.0",
+    "gulp-karma": "0.0.4",
     "gulp-util": "^3.0.4",
     "jest-cli": "^0.4.3",
     "jshint-jsx": "^0.4.1",
     "jshint-stylish": "^1.0.1",
+    "karma-mocha": "^0.1.10",
+    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-sinon-chai": "^0.3.0",
+    "karma-webpack": "^1.5.1",
     "lodash": "^3.8.0",
+    "phantomjs-polyfill": "0.0.1",
     "react": "^0.13.1",
     "react-hot-loader": "^1.2.7",
     "react-tools": "^0.13.3",
@@ -28,20 +34,5 @@
     "eventemitter3": "^0.1.6",
     "keymirror": "^0.1.0",
     "object-assign": "^2.0.0"
-  },
-  "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/react",
-      "<rootDir>/node_modules/react-tools"
-    ],
-    "testFileExtensions": ["es6", "js"],
-    "moduleFileExtensions": ["js", "json", "es6"],
-    "testPathDirs": [
-      "<rootDir>/static/js/__tests__"
-    ]
-  },
-  "scripts": {
-      "test": "jest"
   }
 }

--- a/cmd/tchaik/ui/package.json
+++ b/cmd/tchaik/ui/package.json
@@ -16,6 +16,7 @@
     "jshint-jsx": "^0.4.1",
     "jshint-stylish": "^1.0.1",
     "karma-mocha": "^0.1.10",
+    "karma-mocha-reporter": "^1.0.2",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon-chai": "^0.3.0",
     "karma-webpack": "^1.5.1",

--- a/cmd/tchaik/ui/static/js/src/components/ArtworkImage-test.js
+++ b/cmd/tchaik/ui/static/js/src/components/ArtworkImage-test.js
@@ -1,7 +1,3 @@
-var __path__ = '../../src/components/ArtworkImage.js';
-
-jest.dontMock(__path__);
-
 describe('ArtworkImage', function() {
   var React, TestUtils, ArtworkImage;
   var domNode, artworkImage;
@@ -9,7 +5,7 @@ describe('ArtworkImage', function() {
   beforeEach(function() {
     React = require('react/addons');
     TestUtils = React.addons.TestUtils;
-    ArtworkImage = require(__path__);
+    ArtworkImage = require( '../../src/components/ArtworkImage.js');
 
     artworkImage = TestUtils.renderIntoDocument(
       <ArtworkImage path='/artwork/19199193' />
@@ -20,7 +16,7 @@ describe('ArtworkImage', function() {
   describe('in the initial state', function() {
     it('should not be visible', function() {
       var classes = domNode.getAttribute('class').split(' ');
-      expect(classes).not.toContain('visible');
+      expect(classes).not.to.contain('visible');
     });
   });
 
@@ -31,7 +27,7 @@ describe('ArtworkImage', function() {
 
     it('should be visible', function() {
       var classes = domNode.getAttribute('class').split(' ');
-      expect(classes).toContain('visible');
+      expect(classes).to.contain('visible');
     });
   });
 
@@ -42,7 +38,7 @@ describe('ArtworkImage', function() {
 
     it('should be visible', function() {
       var classes = domNode.getAttribute('class').split(' ');
-      expect(classes).not.toContain('visible');
+      expect(classes).not.to.contain('visible');
     });
   });
 

--- a/cmd/tchaik/ui/webpack.common.config.js
+++ b/cmd/tchaik/ui/webpack.common.config.js
@@ -1,0 +1,31 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  plugins: [
+    new webpack.DefinePlugin({
+      "process.env": Object.keys(process.env).reduce(function(o, k) {
+        o[k] = JSON.stringify(process.env[k]);
+        return o;
+      }, {})
+    }),
+  ],
+
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loaders: ['react-hot-loader', 'babel-loader?stage=0'],
+      },
+      {
+        test: /\.scss$/,
+        loader: "style!css!sass?outputStyle=expanded&" +
+          "includePaths[]=" +
+            (path.resolve(__dirname, "./bower_components")) + "&" +
+          "includePaths[]=" +
+            (path.resolve(__dirname, "./node_modules"))
+      },
+    ]
+  }
+};

--- a/cmd/tchaik/ui/webpack.config.js
+++ b/cmd/tchaik/ui/webpack.config.js
@@ -1,7 +1,7 @@
-var path = require('path');
-var webpack = require('webpack');
+var assign = require('object-assign');
+var config = require('./webpack.common.config.js');
 
-module.exports = {
+module.exports = assign({}, config, {
   entry: {
     app: ['./static/js/src/app.js'],
   },
@@ -12,33 +12,4 @@ module.exports = {
     publicPath: '/static/js/build/',
     filename: 'tchaik.js'
   },
-
-  devtool: 'inline-source-maps',
-
-  plugins: [
-    new webpack.DefinePlugin({
-      "process.env": Object.keys(process.env).reduce(function(o, k) {
-        o[k] = JSON.stringify(process.env[k]);
-        return o;
-      }, {})
-    }),
-  ],
-
-  module: {
-    loaders: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        loaders: ['react-hot-loader', 'babel-loader?stage=0'],
-      },
-      {
-        test: /\.scss$/,
-        loader: "style!css!sass?outputStyle=expanded&" +
-          "includePaths[]=" +
-            (path.resolve(__dirname, "./bower_components")) + "&" +
-          "includePaths[]=" +
-            (path.resolve(__dirname, "./node_modules"))
-      },
-    ]
-  }
-};
+});

--- a/cmd/tchaik/ui/webpack.tests.config.js
+++ b/cmd/tchaik/ui/webpack.tests.config.js
@@ -1,0 +1,3 @@
+var config = require('./webpack.common.config.js');
+
+module.exports = config;


### PR DESCRIPTION
This still runs in about the same amount of time as jest, when running in singlerun mode, however I have also introduced the gulp 'karma:dev' target, which will run karma continuously. The re-compilation of JS and re-running the tests in that mode takes less than one second.

Still need to figure out:
- [ ] How to reset the global state for each test