### PR TITLE
Fixed playlist bug - multiple of same track won't delete

### DIFF
--- a/cmd/tchaik/ui/static/js/src/stores/PlaylistStore.js
+++ b/cmd/tchaik/ui/static/js/src/stores/PlaylistStore.js
@@ -298,7 +298,7 @@ function remove(itemIndex, path) {
   setPlaylistItems(items);
   var current = getPlaylistCurrent();
   if (removedItem) {
-    if (current.item === itemIndex) {
+    if (current === null || current.item === itemIndex) {
       current = null;
     }
     setPlaylistCurrent(current);

--- a/cmd/tchaik/ui/static/js/src/stores/PlaylistStore.js
+++ b/cmd/tchaik/ui/static/js/src/stores/PlaylistStore.js
@@ -298,7 +298,7 @@ function remove(itemIndex, path) {
   setPlaylistItems(items);
   var current = getPlaylistCurrent();
   if (removedItem) {
-    if (current === null || current.item === itemIndex) {
+    if (current && current.item === itemIndex) {
       current = null;
     }
     setPlaylistCurrent(current);


### PR DESCRIPTION
Fixed a bug I was experiencing where when you add a track to the playlist and then delete it from the playlist, the playlist view does not update until you switch to a different view (like settings).  This only happens when the track is not the one currently being played.