### PR TITLE
Fixed kind/filetype issue

### DIFF
--- a/index/walk/walk.go
+++ b/index/walk/walk.go
@@ -156,15 +156,15 @@ type kind tag.FileType
 
 func (k kind) String() string {
 	switch k {
-	case tag.MP3:
+	case kind(tag.MP3):
 		return "MPEG audio file"
-	case tag.M4A:
+	case kind(tag.M4A):
 		return "AAC audio file"
-	case tag.ALAC: // FIXME: tag doesn't actually detect this at the moment.
+	case kind(tag.ALAC): // FIXME: tag doesn't actually detect this at the moment.
 		return "Apple Lossless audio file"
-	case tag.FLAC:
+	case kind(tag.FLAC):
 		return "FLAC audio file"
-	case tag.OGG:
+	case kind(tag.OGG):
 		return "OGG audio file"
 	}
 	return ""


### PR DESCRIPTION
Hi everyone, 

I've been looking for something like this project for a while so it was great to find it. And it's in Go! 

Anyway, it didn't compile when I first cloned it due to mismatched types so I put an explicit conversion from tag.FileType to kind; now it compiles and runs nicely.

I didn't seem to have permissions to branch from the main repo hence the fork, which seems a little heavy handed for a small change like this.

