### PR TITLE
Updates httpauth.None to use updated httpauth.Skip

### DIFF
--- a/cmd/tchaik/handler.go
+++ b/cmd/tchaik/handler.go
@@ -52,7 +52,7 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 
 // NewHandler creates the root http.Handler.
 func NewHandler(l Library, m *Meta, mediaFileSystem, artworkFileSystem store.FileSystem) http.Handler {
-	var c httpauth.Checker = httpauth.None{}
+	c := httpauth.Skip
 	if authUser != "" {
 		c = httpauth.Creds(map[string]string{
 			authUser: authPassword,


### PR DESCRIPTION
dhowden/httpauth has made a change to update exported `None` to `Skip`. See: https://github.com/dhowden/httpauth/commit/67542f6b157ae95e65be19f6c75e008ddafcd206